### PR TITLE
Use prebuilt Docker images and simplify networking

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -15,25 +15,25 @@ sudo systemctl status bluetooth
 sudo systemctl start bluetooth
 ```
 
-## Step 2: Build the Container
+## Step 2: Pull the Prebuilt Image
 
 ```bash
-cd src
-docker build -t meshmonitor-ble-bridge .
+docker pull ghcr.io/yeraze/meshtastic-ble-bridge:latest
 ```
 
 Expected output:
 ```
-Successfully built <image-id>
-Successfully tagged meshmonitor-ble-bridge:latest
+latest: Pulling from yeraze/meshtastic-ble-bridge
+...
+Status: Downloaded newer image for ghcr.io/yeraze/meshtastic-ble-bridge:latest
 ```
 
 ## Step 3: Scan for Your Meshtastic Device
 
 ```bash
-docker run --rm --privileged --network host \
+docker run --rm --privileged \
   -v /var/run/dbus:/var/run/dbus \
-  meshmonitor-ble-bridge --scan
+  ghcr.io/yeraze/meshtastic-ble-bridge:latest --scan
 ```
 
 Example output:
@@ -72,11 +72,12 @@ Replace `AA:BB:CC:DD:EE:FF` with your device's MAC address:
 
 ```bash
 docker run -d --name ble-bridge \
-  --privileged --network host \
+  --privileged \
+  -p 4403:4403 \
   --restart unless-stopped \
   -v /var/run/dbus:/var/run/dbus \
   -v /var/lib/bluetooth:/var/lib/bluetooth:ro \
-  meshmonitor-ble-bridge AA:BB:CC:DD:EE:FF
+  ghcr.io/yeraze/meshtastic-ble-bridge:latest AA:BB:CC:DD:EE:FF
 ```
 
 ## Step 6: Verify It's Running
@@ -133,10 +134,13 @@ docker logs ble-bridge
 
 ### Can't connect from MeshMonitor?
 ```bash
-# Check bridge is listening
-docker exec ble-bridge netstat -tln | grep 4403
+# Check bridge container is running
+docker ps | grep ble-bridge
 
-# Should show: tcp 0 0 0.0.0.0:4403 0.0.0.0:* LISTEN
+# Check port is exposed
+docker port ble-bridge
+
+# Should show: 4403/tcp -> 0.0.0.0:4403
 
 # Check firewall
 sudo ufw status
@@ -150,11 +154,12 @@ docker stop ble-bridge
 docker rm ble-bridge
 
 docker run -d --name ble-bridge \
-  --privileged --network host \
+  --privileged \
+  -p 4403:4403 \
   --restart unless-stopped \
   -v /var/run/dbus:/var/run/dbus \
   -v /var/lib/bluetooth:/var/lib/bluetooth:ro \
-  meshmonitor-ble-bridge AA:BB:CC:DD:EE:FF --verbose
+  ghcr.io/yeraze/meshtastic-ble-bridge:latest AA:BB:CC:DD:EE:FF --verbose
 
 # Watch logs
 docker logs -f ble-bridge

--- a/README.md
+++ b/README.md
@@ -40,17 +40,16 @@ meshmonitor-ble-bridge/
 - Bluetooth adapter (built-in or USB)
 - Meshtastic device with BLE enabled
 
-### 1. Build the Container
+### 1. Pull the Container
 ```bash
-cd src
-docker build -t meshmonitor-ble-bridge .
+docker pull ghcr.io/yeraze/meshtastic-ble-bridge:latest
 ```
 
 ### 2. Find Your Device
 ```bash
-docker run --rm --privileged --network host \
+docker run --rm --privileged \
   -v /var/run/dbus:/var/run/dbus \
-  meshmonitor-ble-bridge --scan
+  ghcr.io/yeraze/meshtastic-ble-bridge:latest --scan
 ```
 
 ### 3. Pair Your Device (if required)
@@ -64,12 +63,13 @@ exit
 ### 4. Start the Bridge
 ```bash
 docker run -d --name ble-bridge \
-  --privileged --network host \
+  --privileged \
+  -p 4403:4403 \
   --restart unless-stopped \
   -v /var/run/dbus:/var/run/dbus \
   -v /var/lib/bluetooth:/var/lib/bluetooth:ro \
   -v /etc/avahi/services:/etc/avahi/services \
-  meshmonitor-ble-bridge AA:BB:CC:DD:EE:FF
+  ghcr.io/yeraze/meshtastic-ble-bridge:latest AA:BB:CC:DD:EE:FF
 ```
 
 The bridge will automatically register an mDNS service for network autodiscovery.

--- a/docker-compose.ble.yml
+++ b/docker-compose.ble.yml
@@ -6,12 +6,11 @@
 
 services:
   ble-bridge:
-    build:
-      context: ./src
-      dockerfile: Dockerfile
+    image: ghcr.io/yeraze/meshtastic-ble-bridge:latest
     container_name: meshmonitor-ble-bridge
     privileged: true  # Required for BLE hardware access
-    network_mode: host  # Allows localhost TCP communication with meshmonitor
+    ports:
+      - "4403:4403"  # Expose TCP bridge port
     restart: unless-stopped
     volumes:
       - /var/run/dbus:/var/run/dbus  # Required for D-Bus/Bluetooth access
@@ -34,7 +33,7 @@ services:
         exec python3 /app/ble_tcp_bridge.py $CMD --verbose
       '
     healthcheck:
-      test: ["CMD", "python3", "-c", "import socket; s = socket.socket(); s.connect(('127.0.0.1', 4403)); s.close()"]
+      test: ["CMD", "python3", "-c", "import socket; s = socket.socket(); s.connect(('localhost', 4403)); s.close()"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -43,8 +42,8 @@ services:
   # Override meshmonitor service to connect to BLE bridge
   meshmonitor:
     environment:
-      # Configure MeshMonitor to connect to the BLE bridge
-      - MESHTASTIC_NODE_IP=localhost
+      # Configure MeshMonitor to connect to the BLE bridge via Docker network
+      - MESHTASTIC_NODE_IP=ble-bridge
       - MESHTASTIC_NODE_PORT=4403
     depends_on:
       ble-bridge:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,11 @@
 
 services:
   ble-bridge:
-    build:
-      context: ./src
-      dockerfile: Dockerfile
+    image: ghcr.io/yeraze/meshtastic-ble-bridge:latest
     container_name: meshmonitor-ble-bridge
     privileged: true  # Required for BLE hardware access
-    network_mode: host  # Allows localhost TCP communication
+    ports:
+      - "4403:4403"  # Expose TCP bridge port
     restart: unless-stopped
     volumes:
       - /var/run/dbus:/var/run/dbus  # Required for D-Bus/Bluetooth access
@@ -23,7 +22,7 @@ services:
       - BLE_ADDRESS=48:CA:43:59:4C:71
     command: --verbose
     healthcheck:
-      test: ["CMD", "python3", "-c", "import socket; s = socket.socket(); s.connect(('127.0.0.1', 4403)); s.close()"]
+      test: ["CMD", "python3", "-c", "import socket; s = socket.socket(); s.connect(('localhost', 4403)); s.close()"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docs/DEPLOY_BLE_BRIDGE.md
+++ b/docs/DEPLOY_BLE_BRIDGE.md
@@ -1,6 +1,6 @@
 # Deploy BLE Bridge Container
 
-This file contains the MeshMonitor BLE-to-TCP bridge Docker image.
+This guide shows how to deploy the MeshMonitor BLE-to-TCP bridge using the prebuilt Docker image.
 
 ## Requirements
 
@@ -10,25 +10,26 @@ This file contains the MeshMonitor BLE-to-TCP bridge Docker image.
 
 ## Installation
 
-### 1. Load the Docker Image
+### 1. Pull the Docker Image
 
 ```bash
-docker load -i meshmonitor-ble-bridge.tar
+docker pull ghcr.io/yeraze/meshtastic-ble-bridge:latest
 ```
 
 You should see:
 ```
-Loaded image: meshmonitor-ble-bridge:latest
+latest: Pulling from yeraze/meshtastic-ble-bridge
+...
+Status: Downloaded newer image for ghcr.io/yeraze/meshtastic-ble-bridge:latest
 ```
 
 ### 2. Find Your Meshtastic Device
 
 ```bash
-docker run --rm --privileged --network host \
+docker run --rm --privileged \
   -v /var/run/dbus:/var/run/dbus \
   -v /var/lib/bluetooth:/var/lib/bluetooth:ro \
-  -v /etc/avahi/services:/etc/avahi/services \
-  meshmonitor-ble-bridge --scan
+  ghcr.io/yeraze/meshtastic-ble-bridge:latest --scan
 ```
 
 Output will show devices like:
@@ -67,12 +68,13 @@ Once paired, the container will reuse this pairing information via D-Bus.
 
 ```bash
 docker run -d --name ble-bridge \
-  --privileged --network host \
+  --privileged \
+  -p 4403:4403 \
   --restart unless-stopped \
   -v /var/run/dbus:/var/run/dbus \
   -v /var/lib/bluetooth:/var/lib/bluetooth:ro \
   -v /etc/avahi/services:/etc/avahi/services \
-  meshmonitor-ble-bridge AA:BB:CC:DD:EE:FF
+  ghcr.io/yeraze/meshtastic-ble-bridge:latest AA:BB:CC:DD:EE:FF
 ```
 
 Replace `AA:BB:CC:DD:EE:FF` with your device's MAC address from step 2.
@@ -81,6 +83,9 @@ Replace `AA:BB:CC:DD:EE:FF` with your device's MAC address from step 2.
 - `/var/run/dbus` - Required for Bluetooth D-Bus communication
 - `/var/lib/bluetooth` - Pairing information (read-only)
 - `/etc/avahi/services` - mDNS service registration for autodiscovery
+
+**Port Exposure:**
+- `-p 4403:4403` - Exposes the TCP bridge port to the host
 
 ### 4. Verify It's Running
 
@@ -183,12 +188,13 @@ sudo systemctl restart bluetooth
 
 # Try again
 docker run -d --name ble-bridge \
-  --privileged --network host \
+  --privileged \
+  -p 4403:4403 \
   --restart unless-stopped \
   -v /var/run/dbus:/var/run/dbus \
   -v /var/lib/bluetooth:/var/lib/bluetooth:ro \
   -v /etc/avahi/services:/etc/avahi/services \
-  meshmonitor-ble-bridge AA:BB:CC:DD:EE:FF --verbose
+  ghcr.io/yeraze/meshtastic-ble-bridge:latest AA:BB:CC:DD:EE:FF --verbose
 ```
 
 ### View Detailed Logs
@@ -206,19 +212,20 @@ docker rm ble-bridge
 
 ## Custom TCP Port
 
-If port 4403 is already in use:
+If port 4403 is already in use on the host:
 
 ```bash
 docker run -d --name ble-bridge \
-  --privileged --network host \
+  --privileged \
+  -p 14403:4403 \
   --restart unless-stopped \
   -v /var/run/dbus:/var/run/dbus \
   -v /var/lib/bluetooth:/var/lib/bluetooth:ro \
   -v /etc/avahi/services:/etc/avahi/services \
-  meshmonitor-ble-bridge AA:BB:CC:DD:EE:FF --port 14403
+  ghcr.io/yeraze/meshtastic-ble-bridge:latest AA:BB:CC:DD:EE:FF
 ```
 
-Then configure MeshMonitor with `MESHTASTIC_NODE_PORT=14403`
+This maps host port 14403 to container port 4403. Then configure MeshMonitor with `MESHTASTIC_NODE_PORT=14403`
 
 **Note:** The mDNS service will automatically advertise the custom port in its TXT records.
 


### PR DESCRIPTION
## Summary

- Replace local build instructions with `docker pull` from GitHub Container Registry
- Remove host networking in favor of exposing only port 4403
- Update docker-compose files to use prebuilt images
- Improve container security and isolation

## Changes

### Docker Compose Files
- **docker-compose.yml**: Use `ghcr.io/yeraze/meshtastic-ble-bridge:latest` instead of building locally
- **docker-compose.ble.yml**: Use prebuilt image, configure meshmonitor to connect via Docker service name

### Documentation Updates
- **QUICK_START.md**: Replace "Build the Container" step with "Pull the Prebuilt Image"
- **README.md**: Update Quick Start section to use prebuilt images
- **docs/DEPLOY_BLE_BRIDGE.md**: Replace `docker load` with `docker pull`

### Networking Changes
All deployment methods now use:
- **Image**: `ghcr.io/yeraze/meshtastic-ble-bridge:latest`
- **Network**: `-p 4403:4403` instead of `--network host`
- **Benefits**: Better container isolation and security while maintaining full functionality

## Benefits

1. **Easier Deployment**: Users can pull and run immediately without building
2. **Consistency**: Everyone uses the same tested images from GHCR
3. **Better Security**: Container is more isolated with port-based networking instead of host networking
4. **Simplified Networking**: Only exposes the single required port (4403)

## Testing

- [ ] Verify `docker-compose up` works with prebuilt image
- [ ] Verify standalone `docker run` commands work
- [ ] Verify MeshMonitor can connect to bridge via exposed port
- [ ] Verify mDNS autodiscovery still functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)